### PR TITLE
Fixed typo in english translations

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -35,7 +35,7 @@
 
     "progress_popup_title" : {
         "message" : "Downloading $SUBJECT$...",
-        "description" : "This will appear on screen during the subject download as the TITLE.",
+        "description" : "This will appear on-screen during the subject download as the TITLE.",
         "placeholders" : {
             "subject" : {
                 "content" : "$1",


### PR DESCRIPTION
Forgot a "-" ._.