### PR TITLE
Alerts are hidden after 10s by default.

### DIFF
--- a/js/download_popup.js
+++ b/js/download_popup.js
@@ -52,8 +52,14 @@ function fnon_update_compressing(url_or_name) {
     document.getElementById('fnon_content').innerHTML = '<p style="font-size:16px;color:#1f7dde;" align="center"><em>' + browser.i18n.getMessage("progress_popup_compressing", url_or_name) + '</em></p>';
 }
 
-function fnon_alert(msgstr, title, okstr=browser.i18n.getMessage("close")) {
-    Fnon.Alert.Warning(msgstr, title, okstr);
+function fnon_alert(msgstr, title, okstr=browser.i18n.getMessage("close"), autoremove=true) {
+    if (autoremove) {
+        let alert_timeout = setTimeout(function() {
+            $("button.f__btn").first().click();
+        }, 10000);
+    }
+
+    Fnon.Alert.Warning(msgstr, title, okstr, function() {clearTimeout(alert_timeout);});
 }
 
 function fnon_panic(msgstr, title=browser.i18n.getMessage("error")) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "__MSG_extension_name__",
     "description": "__MSG_extension_description__",
-    "version": "1.5",
+    "version": "1.5.1",
     "manifest_version": 2,
     "author" : "Eric Roy",
     "default_locale" : "en",


### PR DESCRIPTION
After Alex's request, after a 10 second timeout, the alerts of success and error will be hidden.
This is just fashion, not useful. But it was pretty fast to implement.