### PR TITLE
Course guide's tab is shown directly

### DIFF
--- a/config/links.json
+++ b/config/links.json
@@ -10,7 +10,7 @@
     "new_schedule_with_alert" : "https://epsem.upc.edu/thor/PG/Grups.php?t=14&show_alert=true&setup=true",
     "see_schedule" : "https://epsem.upc.edu/thor/PG/Horari.php",
 
-    "course_guides_cat" : "https://www.epsem.upc.edu/ca/estudis/graus/grau-en-enginyeria-de-sistemes-tic#pla",
+    "course_guides_cat" : "https://www.epsem.upc.edu/ca/estudis/graus/grau-en-enginyeria-de-sistemes-tic#plan",
     "course_guides_esp" : "https://www.epsem.upc.edu/es/estudios/grados/grado-en-ingenieria-en-sistemas-tic#plan",
     "course_guides_ing" : "https://www.upc.edu/en/bachelors/ict-systems-engineering-manresa-epsem#plan",
 

--- a/js/student_plan/viewer_epsem.js
+++ b/js/student_plan/viewer_epsem.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Eric Roy
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see http://www.gnu.org/licenses/.
+*/
+
+(function () {
+    scroll_to_plan = window.location.href.endsWith('#plan');
+
+    if (scroll_to_plan) {
+        $(document).ready( function () {
+            $('a[href="#pla"]').parent().addClass('active');
+            $('a[href="#presentacio"]').parent().removeClass('active');
+
+            $('#pla').addClass('active');
+            $('#presentacio').removeClass('active');
+
+            var offTop = $('#myTab').offset().top;
+
+            //$(document).scrollTop(offTop); does nothing in Chrome ...
+            window.scrollTo({top: offTop, behavior: 'smooth'});
+        });
+    }
+})();

--- a/js/student_plan/viewer_upcweb.js
+++ b/js/student_plan/viewer_upcweb.js
@@ -15,5 +15,21 @@
  * this program. If not, see http://www.gnu.org/licenses/.
 */
 
+(function () {
+    scroll_to_plan = window.location.href.endsWith('#plan');
 
-console.log('hello');
+    if (scroll_to_plan) {
+        $(document).ready( function () {
+            var select = $('a[href="#collapse-images-collapse-curriculum"]');
+
+            $('#collapse-images-collapse-curriculum')
+            .attr('style', '').attr('aria-expanded', 'true')
+            .addClass('in');
+            select.attr('aria-expanded', 'true').attr('class', '');
+
+            var offTop = select.offset().top - 100;
+            //$(document).scrollTop(offTop); does nothing in Chrome ...
+            window.scrollTo({top: offTop, behavior: 'smooth'});
+        });
+    }
+})();

--- a/js/student_plan/viewer_upcweb.js
+++ b/js/student_plan/viewer_upcweb.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2022 Eric Roy
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see http://www.gnu.org/licenses/.
+*/
+
+
+console.log('hello');

--- a/manifest.json
+++ b/manifest.json
@@ -121,6 +121,41 @@
             "css": [
             ],
             "run_at": "document_end"
+        },
+
+        {
+            "matches": [
+                "*://www.epsem.upc.edu/ca/estudis/graus/grau-en-enginyeria-de-sistemes-tic",
+                "*://www.epsem.upc.edu/es/estudios/grados/grado-en-ingenieria-en-sistemas-tic*"
+            ],
+            "all_frames": true,
+            "js": [
+                "include/browser-polyfill.min.js",
+                "include/jquery-3.4.1.min.js",
+                "js/basics.js",
+                "js/settings.js",
+                "js/student_plan/viewer_epsem.js"
+                ],
+            "css": [
+            ],
+            "run_at": "document_end"
+        },
+
+        {
+            "matches": [
+                "*://www.upc.edu/en/bachelors/ict-systems-engineering-manresa-epsem"
+            ],
+            "all_frames": true,
+            "js": [
+                "include/browser-polyfill.min.js",
+                "include/jquery-3.4.1.min.js",
+                "js/basics.js",
+                "js/settings.js",
+                "js/student_plan/viewer_upcweb.js"
+                ],
+            "css": [
+            ],
+            "run_at": "document_end"
         }
     ],
 


### PR DESCRIPTION
When the course guide page is showed, we scroll and open the Course Guide tab with jQuery.

That way the user doesn't have to do those two clicks.