### PR TITLE
Fixed padding issue on OCW's landpage

### DIFF
--- a/html/ocw_landpage.html
+++ b/html/ocw_landpage.html
@@ -64,7 +64,6 @@
 
     td {
         border: 1px solid #007bb1;
-        padding: 5px;
         background: unset;
         transition: background 0.1s ease-in-out;
     }
@@ -75,6 +74,7 @@
 
     .ocwnotfound td {
         opacity: 50%;
+        padding: 5px;
     }
     .ocwnotfound td:hover {
         cursor: not-allowed;
@@ -108,6 +108,7 @@
         text-decoration: none;
         color: #696969;
         display: block;
+        padding: 5px;
     }
 
 </style>


### PR DESCRIPTION
Now the anchor tag occupies all the space of the td tag.